### PR TITLE
[Backline] Update zod package in . to resolve High SCA vulnerabilities ✅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react-dom": "16.14.0",
         "react-query": "^3.39.3",
         "react-router-dom": "4.3.1",
-        "zod": "3.17.5"
+        "zod": "^3.22.3"
       },
       "devDependencies": {
         "@babel/core": "^7.26.10",
@@ -7691,9 +7691,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.5.tgz",
-      "integrity": "sha512-La5nhC8xGXEQBUohQq7e9R16yXQHjLfIa91wKQrbstTXA/GbAPGtiY2e/F05shumw+W0s3ms+R6LoIWGcMvJ4A==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-dom": "16.14.0",
     "react-query": "^3.39.3",
     "react-router-dom": "4.3.1",
-    "zod": "3.17.5"
+    "zod": "^3.22.3"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",


### PR DESCRIPTION
✅ Backline fixed the vulnerabilities in the following packages:
### zod
| Severity | CVE | Description | Tool | Link |
| --- | --- | --- | --- | --- |
| 🟧 High | CVE-2025-30269 | https://github.com/EtaySchur/react-app-dep has [CVE-2025-30269] in zod:3.17.5 | csv | - |

<details>
<summary><b>Remediation Plan</b></summary>

### Our AI agents developed the remediation plan outlined below to remediate the identified vulnerabilities:
#### The breaking change involves the 'addQuestionMarks' type in the 'zod/objectUtil' package. The new version introduces an additional generic parameter 'R' and changes the type composition logic. Update your code to accommodate these changes.
- Update the 'addQuestionMarks' type usage to include the new generic parameter 'R'. If 'R' is not specified, it defaults to 'requiredKeys<T>'.
- Adjust the logic in your code where 'addQuestionMarks' is used to align with the new type definition: 'Pick<Required<T>, R> & Partial<T>'.
#### Update the type definition to include the new issue type in the union.
- Add 'ZodNotFiniteIssue' to the 'ZodIssueOptionalMessage' type union.
#### The 'defaultErrorMap' function signature has changed, requiring updates to its usage in the codebase.
- Update the 'defaultErrorMap' function signature to match the new expected parameters and return type.
#### Update the type definition to include the new issue type in the union.
- Add 'ZodNotFiniteIssue' to the 'ZodIssueOptionalMessage' type union.
#### The breaking change in the 'zod' package involves a modification in the 'objectType' function signature. The new version introduces 'baseObjectOutputType' and 'baseObjectInputType' in place of 'objectUtil.addQuestionMarks'. Update your code to align with the new function signature.
- Replace 'objectUtil.addQuestionMarks<{ [k in keyof T]: T[k]["_output"]; }>' with 'baseObjectOutputType<T>'.
- Replace 'objectUtil.addQuestionMarks<{ [k in keyof T]: T[k]["_input"]; }>' with 'baseObjectInputType<T>'.
#### The breaking change in the 'zod' package involves a modification in the 'objectType' function signature. The new version introduces 'baseObjectOutputType' and 'baseObjectInputType' in place of 'objectUtil.addQuestionMarks'. Update your code to align with the new function signature.
- Replace 'objectUtil.addQuestionMarks<{ [k in keyof T]: T[k]["_output"]; }>' with 'baseObjectOutputType<T>'.
- Replace 'objectUtil.addQuestionMarks<{ [k in keyof T]: T[k]["_input"]; }>' with 'baseObjectInputType<T>'.
</details>