### PR TITLE
[Backline] Update zod package in . to resolve High SCA vulnerabilities ✅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react-dom": "16.14.0",
         "react-query": "^3.39.3",
         "react-router-dom": "4.3.1",
-        "zod": "3.17.5"
+        "zod": "^3.22.3"
       },
       "devDependencies": {
         "@babel/core": "^7.26.10",
@@ -7691,9 +7691,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.5.tgz",
-      "integrity": "sha512-La5nhC8xGXEQBUohQq7e9R16yXQHjLfIa91wKQrbstTXA/GbAPGtiY2e/F05shumw+W0s3ms+R6LoIWGcMvJ4A==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-dom": "16.14.0",
     "react-query": "^3.39.3",
     "react-router-dom": "4.3.1",
-    "zod": "3.17.5"
+    "zod": "^3.22.3"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",


### PR DESCRIPTION
✅ Backline fixed the vulnerabilities in the following packages:
### zod
| Severity | CVE | Description | Tool | Link |
| --- | --- | --- | --- | --- |
| 🟧 High | CVE-2024-fe806a5e-f413-4d43-ab51-023d2e328965 | https://github.com/EtaySchur/react-app-dep has [CVE-2024-fe806a5e-f413-4d43-ab51-023d2e328965] in zod:3.17.5 | csv | - |