### PR TITLE
[Backline] Update zod package in . to resolve High SCA vulnerabilities ✅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react-dom": "16.14.0",
         "react-query": "^3.39.3",
         "react-router-dom": "4.3.1",
-        "zod": "3.17.5"
+        "zod": "^3.22.3"
       },
       "devDependencies": {
         "@babel/core": "^7.26.10",
@@ -9019,9 +9019,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.5.tgz",
-      "integrity": "sha512-La5nhC8xGXEQBUohQq7e9R16yXQHjLfIa91wKQrbstTXA/GbAPGtiY2e/F05shumw+W0s3ms+R6LoIWGcMvJ4A==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-dom": "16.14.0",
     "react-query": "^3.39.3",
     "react-router-dom": "4.3.1",
-    "zod": "3.17.5"
+    "zod": "^3.22.3"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",

--- a/src/utils/zodUtils.ts
+++ b/src/utils/zodUtils.ts
@@ -26,7 +26,7 @@ export type ExampleFormType = {
   phone?: string;
 };
 
-export type TransformedFormType = objectUtil.addQuestionMarks<ExampleFormType>;
+export type TransformedFormType = objectUtil.addQuestionMarks<ExampleFormType, never>;
 
 // Simple demo
 export const demonstrateAddQuestionMarks = (): TransformedFormType => {

--- a/src/utils/zodUtils.ts
+++ b/src/utils/zodUtils.ts
@@ -7,7 +7,8 @@ import {
 // Utility function using the removed defaultErrorMap
 export const createCustomErrorMap = (customMessages: Record<string, string> = {}) => {
   return (issue: ZodIssueOptionalMessage, ctx: { defaultError: string; data: any }) => {
-    const defaultResult = defaultErrorMap(issue, ctx);
+    // Instead of using the removed defaultErrorMap, create a default error message based on the issue
+    const defaultResult = { message: ctx.defaultError };
     
     const fieldName = issue.path?.[0];
     if (fieldName && customMessages[fieldName as string]) {


### PR DESCRIPTION
✅ Backline fixed the vulnerabilities in the following packages:
### zod
| Severity | CVE | Description | Tool | Link |
| --- | --- | --- | --- | --- |
| 🟧 High | CVE-2025-30301 | https://github.com/EtaySchur/react-app-dep has [CVE-2025-30301] in zod:3.17.5 | csv | - |

<details>
<summary><b>Remediation Plan</b></summary>

### Our AI agents developed the remediation plan outlined below to remediate the identified vulnerabilities:
#### Update the usage of 'addQuestionMarks' type to accommodate the new signature with an additional generic parameter.
- Update all instances of 'addQuestionMarks<T>' to 'addQuestionMarks<T, R>' where 'R' is the required keys of 'T'.
#### The function 'defaultErrorMap' has been removed from the 'zod' package. You need to replace its usage with the new error mapping approach provided by the package.
- Remove any usage of 'defaultErrorMap' from your code.
- Implement a custom error mapping function using the new error handling approach provided by 'zod'.
#### The breaking change involves the addition of a new type, ZodNotFiniteIssue, to the ZodIssueOptionalMessage type union. Update any type checks or handling logic to accommodate this new type.
- Update type checks or handling logic to include ZodNotFiniteIssue in any switch cases or conditional logic that processes ZodIssueOptionalMessage types.
#### The breaking change involves the addition of a new type, ZodNotFiniteIssue, to the ZodIssueOptionalMessage type union. Update any type checks or handling logic to accommodate this new type.
- Update type checks or handling logic to include ZodNotFiniteIssue in any switch cases or conditional logic that processes ZodIssueOptionalMessage types.
#### The breaking change in the 'zod' package involves a modification in the 'objectType' function signature, affecting how object shapes are handled. The new signature uses 'baseObjectOutputType' and 'baseObjectInputType' instead of the previous 'objectUtil.addQuestionMarks'.
- Update all instances of 'objectType' to use the new signature with 'baseObjectOutputType' and 'baseObjectInputType'.
#### The breaking change in the 'zod' package involves a modification in the 'objectType' function signature, affecting how object shapes are handled. The new signature uses 'baseObjectOutputType' and 'baseObjectInputType' instead of the previous 'objectUtil.addQuestionMarks'.
- Update all instances of 'objectType' to use the new signature with 'baseObjectOutputType' and 'baseObjectInputType'.
</details>