### PR TITLE
[Backline] Update date-fns package to resolve High SCA vulnerabilities ✅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/react-dom": "^16.9.0",
         "@types/react-router-dom": "^4.3.1",
         "babel-loader": "^10.0.0",
-        "concurrently": "^8.2.2",
+        "concurrently": "^9.2.0",
         "css-loader": "^7.1.2",
         "html-webpack-plugin": "^5.6.3",
         "karma": "5.0.0",
@@ -3276,18 +3276,16 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
-      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
+      "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
-        "date-fns": "^2.30.0",
         "lodash": "^4.17.21",
         "rxjs": "^7.8.1",
         "shell-quote": "^1.8.1",
-        "spawn-command": "0.0.2",
         "supports-color": "^8.1.1",
         "tree-kill": "^1.2.2",
         "yargs": "^17.7.2"
@@ -3297,7 +3295,7 @@
         "concurrently": "dist/bin/concurrently.js"
       },
       "engines": {
-        "node": "^14.13.0 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
@@ -3820,23 +3818,6 @@
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
     },
     "node_modules/date-format": {
       "version": "2.1.0",
@@ -8741,12 +8722,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/spawn-command": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
-      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
-      "dev": true
     },
     "node_modules/spdy": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/react-dom": "^16.9.0",
     "@types/react-router-dom": "^4.3.1",
     "babel-loader": "^10.0.0",
-    "concurrently": "^8.2.2",
+    "concurrently": "^9.2.0",
     "css-loader": "^7.1.2",
     "html-webpack-plugin": "^5.6.3",
     "karma": "5.0.0",


### PR DESCRIPTION
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Backline-AI/Docs/refs/heads/main/logo-light.svg" width="100px" height="50px">
  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Backline-AI/Docs/refs/heads/main/logo-dark.svg" width="100px" height="50px">
  <img src="https://raw.githubusercontent.com/Backline-AI/Docs/refs/heads/main/logo-dark.svg">
</picture>

✅ This pull request was created and verified by Backline to fix the vulnerabilities in the following packages:
### date-fns
<img src="https://raw.githubusercontent.com/Backline-AI/Docs/refs/heads/main/high.svg">
CVE-2025-30403 -  
<br>
<br>
<br>

<details>
<summary><b>Remediation Plan</b></summary> <br>

📝 Backline has developed the remediation plan outlined below to remediate the identified vulnerabilities:
#### The 'mk' Locale symbol was removed from 'date-fns/esm/locale'.
- Remove any import statements for 'mk' from 'date-fns/esm/locale'.
- Replace usage of 'mk' Locale with an alternative or custom implementation.
#### The 'af' Locale symbol was removed from 'date-fns/esm/locale'.
- Remove any import or usage of 'af' Locale from 'date-fns/esm/locale'.
#### The 'fr' locale was removed from 'date-fns/esm/locale'. Replace its usage with an alternative locale or remove it if not needed.
- Remove import of 'fr' from 'date-fns/esm/locale'.
- Replace 'fr' usage with another locale, e.g., 'enUS', if needed.
#### The 'nlBE' locale was removed from 'date-fns/esm/locale'.
- Remove any import or usage of 'nlBE' from 'date-fns/esm/locale'.
- Replace 'nlBE' with an alternative locale, such as 'nl', if applicable.
#### The 'getSeconds' function was removed from 'date-fns/esm/fp'. Replace its usage with 'getSeconds' from 'date-fns'.
- Replace 'import { getSeconds } from "date-fns/esm/fp";' with 'import { getSeconds } from "date-fns";'.
- Update all calls to 'getSeconds' to use the new import path.
#### The 'hr' Locale symbol was removed from 'date-fns/esm/locale'.
- Remove any import or usage of 'hr' Locale from 'date-fns/esm/locale'.
- Replace 'hr' Locale usage with an alternative or custom implementation if needed.
#### The 'da' locale symbol was removed from 'date-fns/esm/locale'. Replace its usage with an alternative locale or remove it if not needed.
- Remove import of 'da' from 'date-fns/esm/locale'.
- Replace 'da' locale usage with another locale, e.g., 'enUS', if needed.
#### The 'getMonth' function from 'date-fns/esm/fp' has been removed. Replace its usage with the standard JavaScript 'Date' object's 'getMonth' method.
- Replace 'getMonth(date)' with '(new Date(date)).getMonth()'.
#### The 'el' Locale symbol was removed from 'date-fns/esm/locale'.
- Remove any import or usage of 'el' from 'date-fns/esm/locale'.
- Replace 'el' with an alternative locale if needed, such as 'enUS' or another supported locale.
#### The 'ptBR' Locale symbol was removed from 'date-fns/esm/locale'.
- Replace 'ptBR' with 'pt' in all imports from 'date-fns/esm/locale'.
- Update any usage of 'ptBR' to 'pt' in the codebase.
#### The 'startOfSecond' function was removed from 'date-fns/esm/fp'. Replace its usage with an alternative approach.
- Replace 'startOfSecond(date)' with 'new Date(Math.floor(date.getTime() / 1000) * 1000)' to achieve similar functionality.
#### The 'arDZ' locale was removed from 'date-fns/esm/locale'. Replace its usage with an alternative locale or remove it if not needed.
- Replace 'arDZ' with 'ar' in all imports from 'date-fns/esm/locale'.
- If 'ar' is not suitable, choose another locale from 'date-fns/esm/locale' that fits your needs.
#### The 'setQuarter' function was removed from 'date-fns/esm/fp'. Replace its usage with an alternative approach.
- Replace 'setQuarter' with a custom function to set the quarter on a Date object.
#### The 'mk' Locale symbol was removed from 'date-fns/esm/locale'.
- Remove any import statements for 'mk' from 'date-fns/esm/locale'.
- Replace usage of 'mk' Locale with an alternative or custom implementation.
#### The 'af' Locale symbol was removed from 'date-fns/esm/locale'.
- Remove any import or usage of 'af' Locale from 'date-fns/esm/locale'.
#### The 'fr' locale was removed from 'date-fns/esm/locale'. Replace its usage with an alternative locale or remove it if not needed.
- Remove import of 'fr' from 'date-fns/esm/locale'.
- Replace 'fr' usage with another locale, e.g., 'enUS', if needed.
#### The 'nlBE' locale was removed from 'date-fns/esm/locale'.
- Remove any import or usage of 'nlBE' from 'date-fns/esm/locale'.
- Replace 'nlBE' with an alternative locale, such as 'nl', if applicable.
#### The 'getSeconds' function was removed from 'date-fns/esm/fp'. Replace its usage with 'getSeconds' from 'date-fns'.
- Replace 'import { getSeconds } from "date-fns/esm/fp";' with 'import { getSeconds } from "date-fns";'.
- Update all calls to 'getSeconds' to use the new import path.
#### The 'hr' Locale symbol was removed from 'date-fns/esm/locale'.
- Remove any import or usage of 'hr' Locale from 'date-fns/esm/locale'.
- Replace 'hr' Locale usage with an alternative or custom implementation if needed.
#### The 'da' locale symbol was removed from 'date-fns/esm/locale'. Replace its usage with an alternative locale or remove it if not needed.
- Remove import of 'da' from 'date-fns/esm/locale'.
- Replace 'da' locale usage with another locale, e.g., 'enUS', if needed.
#### The 'getMonth' function from 'date-fns/esm/fp' has been removed. Replace its usage with the standard JavaScript 'Date' object's 'getMonth' method.
- Replace 'getMonth(date)' with '(new Date(date)).getMonth()'.
#### The 'el' Locale symbol was removed from 'date-fns/esm/locale'.
- Remove any import or usage of 'el' from 'date-fns/esm/locale'.
- Replace 'el' with an alternative locale if needed, such as 'enUS' or another supported locale.
#### The 'ptBR' Locale symbol was removed from 'date-fns/esm/locale'.
- Replace 'ptBR' with 'pt' in all imports from 'date-fns/esm/locale'.
- Update any usage of 'ptBR' to 'pt' in the codebase.
#### The 'startOfSecond' function was removed from 'date-fns/esm/fp'. Replace its usage with an alternative approach.
- Replace 'startOfSecond(date)' with 'new Date(Math.floor(date.getTime() / 1000) * 1000)' to achieve similar functionality.
#### The 'arDZ' locale was removed from 'date-fns/esm/locale'. Replace its usage with an alternative locale or remove it if not needed.
- Replace 'arDZ' with 'ar' in all imports from 'date-fns/esm/locale'.
- If 'ar' is not suitable, choose another locale from 'date-fns/esm/locale' that fits your needs.
#### The 'setQuarter' function was removed from 'date-fns/esm/fp'. Replace its usage with an alternative approach.
- Replace 'setQuarter' with a custom function to set the quarter on a Date object.
</details>
<hr />

[Backline](http://backline.ai) is here to help accelerate the remediation of your security backlog. Here's how we operate:

📥 <b>Fetch Findings</b> – Gather security issues from your scanners
🔍 <b>Analyze Findings</b> – Understand the context and impact
📝 <b>Plan Remediation</b> – Generate a safe and effective fix strategy
👷 <b>Apply Fix</b> – Implement the remediation in code
🧪 <b>Validate Code</b> – Ensure the changes maintain code quality and integrity
✅ <b>Verify</b> – Run tests to ensure correctness and stability
